### PR TITLE
Using cleaner agieval datasets

### DIFF
--- a/dharma/benchmarks/agieval.py
+++ b/dharma/benchmarks/agieval.py
@@ -20,7 +20,7 @@ def craft_agieval(processor, agieval_path, path_final, count=None, seed=None, fo
     lines = []
 
     for dataset in datasets:
-        ds = load_dataset('dmayhem93/' + dataset)
+        ds = load_dataset('hails/' + dataset) # the hails/agieval-* datasetes are based on dmayhem93/agieval-*
         ds = concatenate_datasets([ ds['test']])
 
         for doc in ds:


### PR DESCRIPTION
The datasets currently used for agieval (`dmayhem93/agieval-*`) are a bit unclean which lead to issues like https://huggingface.co/datasets/pharaouk/dharma-2/discussions/1. There are cleaner datasets available (`hails/agieval-*`), which this PR uses.



